### PR TITLE
Calculate voting history bonus using logistic function

### DIFF
--- a/neurons/src/neurons/prior_voting_history.rs
+++ b/neurons/src/neurons/prior_voting_history.rs
@@ -26,18 +26,33 @@ impl PriorVotingHistoryNeuron {
     }
 }
 
-fn round_bonus(round: u32) -> f64 {
-    match round {
-        21.. => 0.1,
-        _ => 0.0,
-    }
+fn generalised_logistic_function(
+    a: f64,
+    k: f64,
+    c: f64,
+    q: f64,
+    b: f64,
+    nu: f64,
+    x_off: f64,
+    x: f64,
+) -> f64 {
+    a + (k - a) / (f64::powf(c + q * f64::exp(-b * (x - x_off)), 1.0 / nu))
+}
+
+fn round_weight(round: u32) -> f64 {
+    generalised_logistic_function(0.0, 1.0, 1.0, 1.0, 1.0, 4.0, 22.0, round as f64)
+}
+
+fn bonus(rounds_weights_sum: f64) -> f64 {
+    generalised_logistic_function(0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 5.0, rounds_weights_sum)
 }
 
 fn calculate_bonus(rounds_participated: &[u32]) -> f64 {
-    rounds_participated
+    let rounds_weights_sum = rounds_participated
         .iter()
-        .map(|round| round_bonus(*round))
-        .sum()
+        .map(|round| round_weight(*round))
+        .sum();
+    bonus(rounds_weights_sum)
 }
 
 impl Neuron for PriorVotingHistoryNeuron {

--- a/neurons/src/quorum.rs
+++ b/neurons/src/quorum.rs
@@ -45,7 +45,10 @@ pub fn normalize_votes(
             let submission = submissions
                 .iter()
                 .find(|sub| sub.name == submission_name)
-                .expect("Missing details for submission");
+                .expect(&format!(
+                    "Missing details for submission: {}",
+                    submission_name
+                ));
             let submission_votes =
                 normalize_votes_for_submission(submission, &submission_votes, delegatees_for_user)?;
             Ok((submission_name, submission_votes))


### PR DESCRIPTION
Replaces current linear voting history bonus method to favor recent voters and allows new people in the community to gain voting power and catch up to more experienced users 