### PR TITLE
Use Address instead of String for voter identifiers

### DIFF
--- a/contracts/governance/src/lib.rs
+++ b/contracts/governance/src/lib.rs
@@ -127,7 +127,7 @@ impl VotingSystem {
     pub fn set_votes_for_submission(
         env: &Env,
         submission_id: String,
-        votes: Map<String, Vote>,
+        votes: Map<Address, Vote>,
     ) -> Result<(), VotingSystemError> {
         require_admin(env);
 
@@ -148,7 +148,7 @@ impl VotingSystem {
         env: &Env,
         submission_id: String,
         round: u32,
-    ) -> Result<Map<String, Vote>, VotingSystemError> {
+    ) -> Result<Map<Address, Vote>, VotingSystemError> {
         read_submission_votes(env, &submission_id, round)
     }
 
@@ -156,7 +156,7 @@ impl VotingSystem {
     pub fn get_votes_for_submission(
         env: &Env,
         submission_id: String,
-    ) -> Result<Map<String, Vote>, VotingSystemError> {
+    ) -> Result<Map<Address, Vote>, VotingSystemError> {
         Self::get_votes_for_submission_round(env, submission_id, Self::get_current_round(env))
     }
 
@@ -211,7 +211,7 @@ impl VotingSystem {
         read_tally_results(env, round)
     }
 
-    pub fn get_voting_power_for_user(env: Env, user: String) -> Result<I256, VotingSystemError> {
+    pub fn get_voting_power_for_user(env: Env, user: Address) -> Result<I256, VotingSystemError> {
         match read_voting_powers(&env, Self::get_current_round(&env)) {
             Ok(voting_powers) => {
                 if let Some(voting_power) = voting_powers.get(user) {
@@ -298,7 +298,7 @@ impl Governance for VotingSystem {
         layer_id: String,
         neuron_id: String,
         round: u32,
-    ) -> Result<Map<String, I256>, VotingSystemError> {
+    ) -> Result<Map<Address, I256>, VotingSystemError> {
         read_neuron_result(env, &layer_id, &neuron_id, round)
     }
 
@@ -306,11 +306,16 @@ impl Governance for VotingSystem {
         env: &Env,
         layer_id: String,
         neuron_id: String,
-    ) -> Result<Map<String, I256>, VotingSystemError> {
+    ) -> Result<Map<Address, I256>, VotingSystemError> {
         Self::get_neuron_result_round(env, layer_id, neuron_id, Self::get_current_round(env))
     }
 
-    fn set_neuron_result(env: Env, layer_id: String, neuron_id: String, result: Map<String, I256>) {
+    fn set_neuron_result(
+        env: Env,
+        layer_id: String,
+        neuron_id: String,
+        result: Map<Address, I256>,
+    ) {
         require_admin(&env);
 
         write_neuron_result(
@@ -328,9 +333,9 @@ impl Governance for VotingSystem {
     fn get_layer_result(
         env: Env,
         layer_id: String,
-    ) -> Result<Map<String, I256>, VotingSystemError> {
+    ) -> Result<Map<Address, I256>, VotingSystemError> {
         let layer = read_layer(&env, &layer_id)?;
-        let mut result: Map<String, Vec<I256>> = Map::new(&env);
+        let mut result: Map<Address, Vec<I256>> = Map::new(&env);
 
         for neuron_id in layer.neurons {
             let neuron_result = Self::get_neuron_result(&env, layer_id.clone(), neuron_id.clone())?;
@@ -355,7 +360,7 @@ impl Governance for VotingSystem {
         require_admin(&env);
 
         let neural_governance = read_neural_governance(&env).unwrap();
-        let mut result: Map<String, I256> = Map::new(&env);
+        let mut result: Map<Address, I256> = Map::new(&env);
         for layer_id in neural_governance.layers {
             let layer_result = VotingSystem::get_layer_result(env.clone(), layer_id)?;
             for (key, value) in layer_result {
@@ -370,7 +375,7 @@ impl Governance for VotingSystem {
         Ok(())
     }
 
-    fn get_voting_powers(env: Env) -> Result<Map<String, I256>, VotingSystemError> {
+    fn get_voting_powers(env: Env) -> Result<Map<Address, I256>, VotingSystemError> {
         read_voting_powers(&env, Self::get_current_round(&env))
     }
 
@@ -406,7 +411,7 @@ fn create_or_update_layer(
     write_neural_governance(&env, neural_governance);
 }
 
-fn weigh_neuron_result(env: &Env, weight: &I256, result: Map<String, I256>) -> Map<String, I256> {
+fn weigh_neuron_result(env: &Env, weight: &I256, result: Map<Address, I256>) -> Map<Address, I256> {
     let mut scaled = Map::new(env);
 
     for (key, value) in result {

--- a/contracts/governance/src/neural_governance.rs
+++ b/contracts/governance/src/neural_governance.rs
@@ -2,7 +2,7 @@
 use crate::fixed_mul_floor::fixed_mul_floor;
 
 // use soroban_fixed_point_math::SorobanFixedPoint;
-use soroban_sdk::{contracttype, Env, Map, String, Vec, I256};
+use soroban_sdk::{contracttype, Address, Env, Map, String, Vec, I256};
 
 pub mod traits;
 
@@ -64,10 +64,10 @@ impl NGQ {
 
 pub(crate) fn aggregate_result(
     env: &Env,
-    result: Map<String, Vec<I256>>,
+    result: Map<Address, Vec<I256>>,
     layer_aggregator: LayerAggregator,
     decimals: I256,
-) -> Map<String, I256> {
+) -> Map<Address, I256> {
     let mut aggregated_result = Map::new(env);
     for (user, res) in result {
         let res = match layer_aggregator {
@@ -86,7 +86,7 @@ pub(crate) fn aggregate_result(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::vec;
+    use soroban_sdk::{testutils::Address as _, vec};
 
     #[test]
     fn creating_neuron() {
@@ -127,9 +127,9 @@ mod tests {
     fn aggregate_empty() {
         let env = Env::default();
 
-        let user1 = String::from_str(&env, "user1");
+        let user1 = Address::generate(&env);
 
-        let mut result: Map<String, Vec<I256>> = Map::new(&env);
+        let mut result: Map<Address, Vec<I256>> = Map::new(&env);
         result.set(user1.clone(), vec![&env]);
 
         let aggregated = aggregate_result(
@@ -145,10 +145,10 @@ mod tests {
     fn aggregate_sum() {
         let env = Env::default();
 
-        let user1 = String::from_str(&env, "user1");
-        let user2 = String::from_str(&env, "user2");
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
 
-        let mut result: Map<String, Vec<I256>> = Map::new(&env);
+        let mut result: Map<Address, Vec<I256>> = Map::new(&env);
         result.set(
             user1.clone(),
             vec![&env, I256::from_i128(&env, 1), I256::from_i128(&env, 2)],
@@ -174,10 +174,10 @@ mod tests {
     fn aggregate_product() {
         let env = Env::default();
 
-        let user1 = String::from_str(&env, "user1");
-        let user2 = String::from_str(&env, "user2");
+        let user1 = Address::generate(&env);
+        let user2 = Address::generate(&env);
 
-        let mut result: Map<String, Vec<I256>> = Map::new(&env);
+        let mut result: Map<Address, Vec<I256>> = Map::new(&env);
         result.set(
             user1.clone(),
             vec![&env, I256::from_i128(&env, 1), I256::from_i128(&env, 2)],

--- a/contracts/governance/src/neural_governance/traits.rs
+++ b/contracts/governance/src/neural_governance/traits.rs
@@ -1,6 +1,6 @@
 use crate::neural_governance::{Layer, LayerAggregator, Neuron, NGQ};
 use crate::types::VotingSystemError;
-use soroban_sdk::{Env, Map, String, Vec, I256};
+use soroban_sdk::{Address, Env, Map, String, Vec, I256};
 
 pub trait Governance {
     /// Add a new layer to the contract.
@@ -38,27 +38,29 @@ pub trait Governance {
         layer_id: String,
         neuron_id: String,
         round: u32,
-    ) -> Result<Map<String, I256>, VotingSystemError>;
+    ) -> Result<Map<Address, I256>, VotingSystemError>;
 
     /// Get a map of user public keys and their voting powers for a neuron for the active round.
     fn get_neuron_result(
         env: &Env,
         layer_id: String,
         neuron_id: String,
-    ) -> Result<Map<String, I256>, VotingSystemError>;
+    ) -> Result<Map<Address, I256>, VotingSystemError>;
 
     /// Set neuron result for the active round.
-    fn set_neuron_result(env: Env, layer_id: String, neuron_id: String, result: Map<String, I256>);
+    fn set_neuron_result(env: Env, layer_id: String, neuron_id: String, result: Map<Address, I256>);
 
     /// Get a map of user public keys and their voting powers for a layer for the active round.
-    fn get_layer_result(env: Env, layer_id: String)
-        -> Result<Map<String, I256>, VotingSystemError>;
+    fn get_layer_result(
+        env: Env,
+        layer_id: String,
+    ) -> Result<Map<Address, I256>, VotingSystemError>;
 
     /// Calculate final voting powers for the active round and write them to contract storage.
     fn calculate_voting_powers(env: Env) -> Result<(), VotingSystemError>;
 
     /// Get a map of user public keys and their voting powers for whole governance for the active round.
-    fn get_voting_powers(env: Env) -> Result<Map<String, I256>, VotingSystemError>;
+    fn get_voting_powers(env: Env) -> Result<Map<Address, I256>, VotingSystemError>;
 
     /// Get a representation of the current NGQ setup.
     fn get_neural_governance(env: &Env) -> Result<NGQ, VotingSystemError>;

--- a/contracts/governance/src/storage.rs
+++ b/contracts/governance/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{Env, Map, String, Vec, I256};
+use soroban_sdk::{Address, Env, Map, String, Vec, I256};
 
 use crate::neural_governance::{Layer, Neuron, NGQ};
 use crate::storage::key_data::{
@@ -60,7 +60,7 @@ pub(crate) fn read_neuron_result(
     layer_id: &String,
     neuron_id: &String,
     round: u32,
-) -> ContractResult<Map<String, I256>> {
+) -> ContractResult<Map<Address, I256>> {
     let key = get_neuron_result_key(layer_id, neuron_id, round);
     env.storage()
         .temporary()
@@ -73,7 +73,7 @@ pub(crate) fn write_neuron_result(
     layer_id: &String,
     neuron_id: &String,
     round: u32,
-    result: &Map<String, I256>,
+    result: &Map<Address, I256>,
 ) {
     let key = get_neuron_result_key(layer_id, neuron_id, round);
     env.storage().temporary().set(&key, result);
@@ -83,7 +83,7 @@ pub(crate) fn read_submission_votes(
     env: &Env,
     submission_id: &String,
     round: u32,
-) -> ContractResult<Map<String, Vote>> {
+) -> ContractResult<Map<Address, Vote>> {
     let key = get_submission_votes_key(submission_id, round);
     env.storage()
         .persistent()
@@ -95,7 +95,7 @@ pub(crate) fn write_submission_votes(
     env: &Env,
     submission_id: &String,
     round: u32,
-    votes: &Map<String, Vote>,
+    votes: &Map<Address, Vote>,
 ) {
     let key = get_submission_votes_key(submission_id, round);
     env.storage().persistent().set(&key, votes);
@@ -127,7 +127,7 @@ pub(crate) fn write_neural_governance(env: &Env, neural_governance: NGQ) {
         .set(&DataKey::NeuralGovernance, &neural_governance);
 }
 
-pub(crate) fn read_voting_powers(env: &Env, round: u32) -> ContractResult<Map<String, I256>> {
+pub(crate) fn read_voting_powers(env: &Env, round: u32) -> ContractResult<Map<Address, I256>> {
     let key = get_voting_powers_key(round);
     env.storage()
         .persistent()
@@ -135,7 +135,7 @@ pub(crate) fn read_voting_powers(env: &Env, round: u32) -> ContractResult<Map<St
         .ok_or(VotingSystemError::VotingPowersNotSet)
 }
 
-pub(crate) fn write_voting_powers(env: &Env, round: u32, voting_powers: &Map<String, I256>) {
+pub(crate) fn write_voting_powers(env: &Env, round: u32, voting_powers: &Map<Address, I256>) {
     let key = get_voting_powers_key(round);
     env.storage().persistent().set(&key, voting_powers);
 }

--- a/contracts/governance/tests/e2e/upgrade.rs
+++ b/contracts/governance/tests/e2e/upgrade.rs
@@ -1,5 +1,8 @@
 use crate::e2e::common::contract_utils::deploy_contract;
-use soroban_sdk::{Env, Map, String, I256};
+use soroban_sdk::{
+    testutils::{Address as _},
+    Address, Env, I256, Map, String
+};
 
 mod mock_contract {
     soroban_sdk::contractimport!(file = "../target/wasm32v1-none/release/mocks.wasm");
@@ -30,8 +33,8 @@ fn storage_is_retained_after_upgrade() {
 
     // Store data using old impl
     let mut result = Map::new(&env);
-    result.set(String::from_str(&env, "user1"), I256::from_i32(&env, 100));
-    result.set(String::from_str(&env, "user2"), I256::from_i32(&env, 200));
+    result.set(Address::generate(&env), I256::from_i32(&env, 100));
+    result.set(Address::generate(&env), I256::from_i32(&env, 200));
     env.mock_all_auths();
 
     contract_client.set_neuron_result(

--- a/contracts/governance/tests/e2e/upgrade.rs
+++ b/contracts/governance/tests/e2e/upgrade.rs
@@ -1,8 +1,5 @@
 use crate::e2e::common::contract_utils::deploy_contract;
-use soroban_sdk::{
-    testutils::{Address as _},
-    Address, Env, I256, Map, String
-};
+use soroban_sdk::{testutils::Address as _, Address, Env, Map, String, I256};
 
 mod mock_contract {
     soroban_sdk::contractimport!(file = "../target/wasm32v1-none/release/mocks.wasm");

--- a/contracts/governance/tests/e2e/voting.rs
+++ b/contracts/governance/tests/e2e/voting.rs
@@ -1,5 +1,7 @@
-use soroban_sdk::testutils::{MockAuth, MockAuthInvoke};
-use soroban_sdk::{vec, Env, IntoVal, Map, String, Vec, I256};
+use soroban_sdk::{
+        testutils::{Address as _, MockAuth, MockAuthInvoke},
+        vec, Address, Env, IntoVal, Map, String, Vec, I256,
+};
 
 use governance::types::{Vote, VotingSystemError};
 use governance::{LayerAggregator, DECIMALS};
@@ -25,9 +27,9 @@ fn voting_data_upload() {
     ));
     contract_client.add_layer(&raw_neurons, &LayerAggregator::Sum);
 
-    let user1 = String::from_str(&env, "user1");
-    let user2 = String::from_str(&env, "user2");
-    let user3 = String::from_str(&env, "user3");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let user3 = Address::generate(&env);
     let submission1 = String::from_str(&env, "submission1");
     let submission2 = String::from_str(&env, "submission2");
 
@@ -148,7 +150,7 @@ fn tally_submission_requires_admin() {
         (submission.clone(), String::from_str(&env, "Applications")),
     ]);
 
-    let user = String::from_str(&env, "user1");
+    let user = Address::generate(&env);
     let mut votes = Map::new(&env);
     votes.set(user.clone(), Vote::Yes);
     env.mock_auths(&[MockAuth {
@@ -278,8 +280,8 @@ fn set_bump_round_flow() {
     contract_client.set_current_round(&25);
 
     let submission = String::from_str(&env, "sub1");
-    let user1 = String::from_str(&env, "user1");
-    let user2 = String::from_str(&env, "user2");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
     let neuron0 = String::from_str(&env, "0");
     let layer0 = String::from_str(&env, "0");
 
@@ -409,8 +411,8 @@ fn get_voting_power_for_user() {
 
     contract_client.set_current_round(&25);
 
-    let user1 = String::from_str(&env, "user1");
-    let user2 = String::from_str(&env, "user2");
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
     let neuron0 = String::from_str(&env, "0");
     let neuron1 = String::from_str(&env, "1");
     let layer0 = String::from_str(&env, "0");
@@ -463,7 +465,7 @@ fn get_voting_power_for_user() {
     // Verify error is returned for invalid user
     assert_eq!(
         contract_client
-            .try_get_voting_power_for_user(&String::from_str(&env, "Random user"))
+            .try_get_voting_power_for_user(&Address::generate(&env))
             .unwrap_err()
             .unwrap(),
         VotingSystemError::NGQResultForVoterMissing

--- a/contracts/governance/tests/e2e/voting.rs
+++ b/contracts/governance/tests/e2e/voting.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{
-        testutils::{Address as _, MockAuth, MockAuthInvoke},
-        vec, Address, Env, IntoVal, Map, String, Vec, I256,
+    testutils::{Address as _, MockAuth, MockAuthInvoke},
+    vec, Address, Env, IntoVal, Map, String, Vec, I256,
 };
 
 use governance::types::{Vote, VotingSystemError};

--- a/contracts/governor/src/contract.rs
+++ b/contracts/governor/src/contract.rs
@@ -373,11 +373,11 @@ mod test {
             )
             .unwrap_or_else(|_| {
                 let mut map = Map::new(env);
-                map.set(address.to_string(), I256::from_i32(env, 0));
+                map.set(address.clone(), I256::from_i32(env, 0));
                 Ok(map)
             })
             .unwrap();
-        result.set(address.to_string(), I256::from_i128(env, new_balance));
+        result.set(address.clone(), I256::from_i128(env, new_balance));
 
         governance_client.set_neuron_result(
             &soroban_sdk::String::from_str(env, "0"),

--- a/contracts/governor/tests/src/governor.rs
+++ b/contracts/governor/tests/src/governor.rs
@@ -135,7 +135,7 @@ impl GovernorFixture<'_> {
             )
             .unwrap_or_else(|_| Ok(Map::new(self.env)))
             .unwrap();
-        result.set(addr.to_string(), nqg_value);
+        result.set(addr.clone(), nqg_value);
 
         self.governance.set_neuron_result(
             &String::from_str(self.env, "0"),

--- a/contracts/mocks/src/lib.rs
+++ b/contracts/mocks/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, contracttype, Env, Map, String, I256};
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Env, Map, String, I256};
 
 #[contracttype]
 #[derive(Clone, Debug, PartialEq)]
@@ -25,7 +25,7 @@ impl MockContract {
         true
     }
 
-    pub fn get_stored_neuron_result(env: &Env) -> Map<String, I256> {
+    pub fn get_stored_neuron_result(env: &Env) -> Map<Address, I256> {
         let key = DataKey::NeuronResultKey(NeuronResultKeyData {
             layer_id: String::from_str(env, "0"),
             neuron_id: String::from_str(env, "0"),

--- a/contracts/scf_token/src/contract.rs
+++ b/contracts/scf_token/src/contract.rs
@@ -117,7 +117,7 @@ fn voting_power_for_user(
     governance_client: &governance::Client,
     address: &Address,
 ) -> I256 {
-    let voting_power: I256 = governance_client.get_voting_power_for_user(&address.to_string());
+    let voting_power: I256 = governance_client.get_voting_power_for_user(&address);
     if voting_power >= I256::from_i32(env, 0) {
         voting_power
     } else {

--- a/contracts/scf_token/tests/e2e/common/contract_utils.rs
+++ b/contracts/scf_token/tests/e2e/common/contract_utils.rs
@@ -68,11 +68,11 @@ pub fn set_nqg_results(
         )
         .unwrap_or_else(|_| {
             let mut map = Map::new(env);
-            map.set(address.to_string(), I256::from_i32(env, 0));
+            map.set(address.clone(), I256::from_i32(env, 0));
             Ok(map)
         })
         .unwrap();
-    result.set(address.to_string(), I256::from_i128(env, new_balance));
+    result.set(address.clone(), I256::from_i128(env, new_balance));
 
     governance_client.set_neuron_result(
         &soroban_sdk::String::from_str(env, "0"),

--- a/contracts/scf_token/tests/e2e/contract.rs
+++ b/contracts/scf_token/tests/e2e/contract.rs
@@ -19,7 +19,7 @@ fn updating_balances() {
 
     let address = Address::generate(&env);
     let mut result = Map::new(&env);
-    result.set(address.to_string(), I256::from_i128(&env, 10_i128.pow(18)));
+    result.set(address.clone(), I256::from_i128(&env, 10_i128.pow(18)));
 
     governance_client.set_neuron_result(
         &String::from_str(&env, "0"),


### PR DESCRIPTION
Replaces String with Address for voter-related identifiers across the governance contract, including votes, voting powers, and neuron results, while keeping String for non-user entities such as submissions, layers, and neurons.