### PR TITLE
Feature/SDFCOMFUND-717 Trust loss NQG sum log curve

### DIFF
--- a/neurons/src/lib.rs
+++ b/neurons/src/lib.rs
@@ -104,7 +104,7 @@ pub fn run_neurons(
     // Trust Loss
     let trust_loss_neuron = TrustLossNeuron::from_data(current_round, trusted_for_user_per_round, neurons_results_sum);
     let trust_loss_neuron_result = trust_loss_neuron.calculate_result(&users_base);
-        
+
     neurons_results.insert("trust_loss_neuron".to_string(), trust_loss_neuron_result);
 
     let results_fixed_point_decimal = results_to_fixed_point_decimal(neurons_results);
@@ -143,9 +143,9 @@ pub fn run_votes_normalization(votes: &str, delegatees_for_user: &str) -> Result
 }
 
 fn results_to_fixed_point_decimal(neurons_results: HashMap<String, HashMap<String, f64>>) -> HashMap<String, HashMap<String, String>> {
-    let mut  output:HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut output: HashMap<String, HashMap<String, String>> = HashMap::new();
     for (neuron_name, result) in neurons_results {
-        let fixed:HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
+        let fixed: HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
         output.insert(neuron_name, fixed);
     }
     output

--- a/neurons/src/lib.rs
+++ b/neurons/src/lib.rs
@@ -84,25 +84,43 @@ pub fn run_neurons(
     let trusted_for_user_current_round = trusted_for_user_per_round.get(&current_round).unwrap();
     let trust_graph_neuron = TrustGraphNeuron::from_data(trusted_for_user_current_round.clone());
 
-    // Trust Loss
-    let trust_loss_neuron = TrustLossNeuron::from_data(current_round, trusted_for_user_per_round);
-
     // Retro Vote Quality
     let retro_vote_quality_neuron = RetroVoteQualityNeuron::from_data(votes_per_round, normalized_votes_per_round, tranche_status_map, submissions_airtable_ids);
 
     // Run all neurons
-    let results = calculate_neuron_results(
+    let mut neurons_results: HashMap<String, HashMap<String, f64>> = calculate_neuron_results(
         &users_base,
         vec![
             Box::new(prior_voting_history_neuron),
             Box::new(assigned_reputation_neuron),
             Box::new(retro_vote_quality_neuron),
             Box::new(trust_graph_neuron),
-            Box::new(trust_loss_neuron),
         ],
     );
 
-    Ok(serde_json::to_string_pretty(&results).unwrap())
+    // calculate nqg scores
+    let neurons_results_sum: HashMap<String, f64> = sum_neurons_results(neurons_results.clone());
+
+    // Trust Loss
+    let trust_loss_neuron = TrustLossNeuron::from_data(current_round, trusted_for_user_per_round, neurons_results_sum);
+    let trust_loss_neuron_result = trust_loss_neuron.calculate_result(&users_base);
+        
+    neurons_results.insert("trust_loss_neuron".to_string(), trust_loss_neuron_result);
+
+    let results_fixed_point_decimal = results_to_fixed_point_decimal(neurons_results);
+
+    Ok(serde_json::to_string_pretty(&results_fixed_point_decimal).unwrap())
+}
+
+fn sum_neurons_results(neurons_results: HashMap<String, HashMap<String, f64>>) -> HashMap<String, f64> {
+    let neurons_sum: HashMap<String, f64> = neurons_results
+        .values()
+        .flat_map(|neuron_result| neuron_result.iter())
+        .fold(HashMap::new(), |mut acc, (user, score)| {
+            *acc.entry(user.clone()).or_default() += score;
+            acc
+        });
+    neurons_sum
 }
 
 #[wasm_bindgen]
@@ -124,12 +142,21 @@ pub fn run_votes_normalization(votes: &str, delegatees_for_user: &str) -> Result
     Ok(serde_json::to_string_pretty(&normalized_votes).unwrap())
 }
 
-fn calculate_neuron_results(users: &[String], neurons: Vec<Box<dyn Neuron>>) -> HashMap<String, HashMap<String, String>> {
-    let mut results: HashMap<String, HashMap<String, String>> = HashMap::new();
+fn results_to_fixed_point_decimal(neurons_results: HashMap<String, HashMap<String, f64>>) -> HashMap<String, HashMap<String, String>> {
+    let mut  output:HashMap<String, HashMap<String, String>> = HashMap::new();
+    for (neuron_name, result) in neurons_results {
+        let fixed:HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
+        output.insert(neuron_name, fixed);
+    }
+    output
+}
+
+fn calculate_neuron_results(users: &[String], neurons: Vec<Box<dyn Neuron>>) -> HashMap<String, HashMap<String, f64>> {
+    let mut results: HashMap<String, HashMap<String, f64>> = HashMap::new();
     for neuron in neurons {
         println!("running {}", neuron.name());
         let result = neuron.calculate_result(users);
-        let result: HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
+        // let result: HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
         results.insert(neuron.name(), result);
     }
     results
@@ -185,5 +212,32 @@ mod tests {
         let rep = &parsed["assigned_reputation_neuron"];
         assert_eq!(rep["alice"], to_fixed_point_decimal(3.0).to_string());
         assert_eq!(rep["bob"], to_fixed_point_decimal(0.0).to_string());
+    }
+
+    fn make_results(data: Vec<(&str, Vec<(&str, f64)>)>) -> HashMap<String, HashMap<String, f64>> {
+        data.into_iter()
+            .map(|(key, users)| (key.to_string(), users.into_iter().map(|(u, v)| (u.to_string(), v)).collect()))
+            .collect()
+    }
+
+    #[test]
+    fn basic_sum() {
+        let input = make_results(vec![("f1", vec![("alice", 1.0), ("bob", 2.0)]), ("f2", vec![("alice", 3.0), ("bob", 4.0)])]);
+        let result = sum_neurons_results(input);
+        assert_eq!(result["alice"], 4.0);
+        assert_eq!(result["bob"], 6.0);
+    }
+
+    #[test]
+    fn four_neurons() {
+        let input = make_results(vec![
+            ("f1", vec![("alice", 1.0), ("bob", 2.0)]),
+            ("f2", vec![("alice", 10.0), ("bob", 20.0)]),
+            ("f3", vec![("alice", 100.0), ("bob", 200.0)]),
+            ("f4", vec![("alice", 1000.0), ("bob", 2000.0)]),
+        ]);
+        let result = sum_neurons_results(input);
+        assert_eq!(result["alice"], 1111.0);
+        assert_eq!(result["bob"], 2222.0);
     }
 }

--- a/neurons/src/lib.rs
+++ b/neurons/src/lib.rs
@@ -113,13 +113,16 @@ pub fn run_neurons(
 }
 
 fn sum_neurons_results(neurons_results: HashMap<String, HashMap<String, f64>>) -> HashMap<String, f64> {
-    let mut neurons_sum: HashMap<String, f64> = neurons_results
-        .values()
-        .flat_map(|neuron_result| neuron_result.iter())
-        .fold(HashMap::new(), |mut acc, (user, score)| {
-            *acc.entry(user.clone()).or_default() += score;
-            acc
-        });
+    // sum in stable neuron-name order: float addition is order-dependent and HashMap
+    // iteration order is randomized, which would make the fixed-point output nondeterministic
+    let mut neuron_names: Vec<&String> = neurons_results.keys().collect();
+    neuron_names.sort();
+    let mut neurons_sum: HashMap<String, f64> = HashMap::new();
+    for name in neuron_names {
+        for (user, score) in &neurons_results[name] {
+            *neurons_sum.entry(user.clone()).or_default() += score;
+        }
+    }
     neurons_sum.values_mut().for_each(|sum| *sum = sum.max(0.0));
     neurons_sum
 }

--- a/neurons/src/lib.rs
+++ b/neurons/src/lib.rs
@@ -156,7 +156,6 @@ fn calculate_neuron_results(users: &[String], neurons: Vec<Box<dyn Neuron>>) -> 
     for neuron in neurons {
         println!("running {}", neuron.name());
         let result = neuron.calculate_result(users);
-        // let result: HashMap<String, String> = result.into_iter().map(|(key, value)| (key, to_fixed_point_decimal(value).to_string())).collect();
         results.insert(neuron.name(), result);
     }
     results

--- a/neurons/src/lib.rs
+++ b/neurons/src/lib.rs
@@ -113,13 +113,14 @@ pub fn run_neurons(
 }
 
 fn sum_neurons_results(neurons_results: HashMap<String, HashMap<String, f64>>) -> HashMap<String, f64> {
-    let neurons_sum: HashMap<String, f64> = neurons_results
+    let mut neurons_sum: HashMap<String, f64> = neurons_results
         .values()
         .flat_map(|neuron_result| neuron_result.iter())
         .fold(HashMap::new(), |mut acc, (user, score)| {
             *acc.entry(user.clone()).or_default() += score;
             acc
         });
+    neurons_sum.values_mut().for_each(|sum| *sum = sum.max(0.0));
     neurons_sum
 }
 
@@ -225,6 +226,14 @@ mod tests {
         let result = sum_neurons_results(input);
         assert_eq!(result["alice"], 4.0);
         assert_eq!(result["bob"], 6.0);
+    }
+
+    #[test]
+    fn negative_sum_is_capped_at_zero() {
+        let input = make_results(vec![("f1", vec![("alice", 1.0), ("bob", 2.0)]), ("f2", vec![("alice", -3.0), ("bob", -1.5)])]);
+        let result = sum_neurons_results(input);
+        assert_eq!(result["alice"], 0.0);
+        assert_eq!(result["bob"], 0.5);
     }
 
     #[test]

--- a/neurons/src/trust_loss.rs
+++ b/neurons/src/trust_loss.rs
@@ -1,17 +1,24 @@
-use crate::neurons::Neuron;
+use crate::{neurons::Neuron, types::generalised_logistic_function};
 use std::collections::HashMap;
 
-const HOW_DEEP: u32 = 32;
+use wasm_bindgen::JsValue;
+use web_sys::{self, console};
 
+const HOW_DEEP: u32 = 32;
 #[derive(Clone, Debug)]
 pub struct TrustLossNeuron {
     round: u32,
     trusted_for_user_per_round: HashMap<u32, HashMap<String, Vec<String>>>,
+    neurons_results_sum: HashMap<String, f64>,
 }
 
 impl TrustLossNeuron {
-    pub fn from_data(round: u32, trusted_for_user_per_round: HashMap<u32, HashMap<String, Vec<String>>>) -> Self {
-        Self { round, trusted_for_user_per_round }
+    pub fn from_data(round: u32, trusted_for_user_per_round: HashMap<u32, HashMap<String, Vec<String>>>, neurons_results_sum: HashMap<String, f64>) -> Self {
+        Self {
+            round,
+            trusted_for_user_per_round,
+            neurons_results_sum,
+        }
     }
     fn find_most_recent_previous_trust_list(&self, target_user: &String) -> Option<Vec<String>> {
         let mut counter: u32 = self.round - 1;
@@ -27,6 +34,9 @@ impl TrustLossNeuron {
         }
         most_recent_previous_trust_list
     }
+    fn sum_nqg_of_users(&self, lost_trust: &Vec<String>) -> f64 {
+        lost_trust.iter().fold(0.0, |acc, user| acc + self.neurons_results_sum.get(user).unwrap())
+    }
 }
 
 impl Neuron for TrustLossNeuron {
@@ -35,7 +45,9 @@ impl Neuron for TrustLossNeuron {
     }
 
     fn calculate_result(&self, users: &[String]) -> HashMap<String, f64> {
-        let mut trust_diff_map: HashMap<String, f64> = users.iter().map(|user| (user.to_string(), 0.0)).collect();
+        let mut result: HashMap<String, f64> = users.iter().map(|user| (user.to_string(), 0.0)).collect();
+        let mut lost_trust_from: HashMap<String, Vec<String>> = HashMap::new();
+
         for user in users {
             // if this user doesn't have trust list for this round, skip this iteration completly
             // it implicates they couldn't have actively removed trust from someone.
@@ -55,14 +67,29 @@ impl Neuron for TrustLossNeuron {
             // iterate over who this user trusted in previous round
             previous_trust_list.iter().for_each(|trusted_user| {
                 if !current_trust_list.contains(trusted_user) {
-                    // only users present in the input slice are tracked in the output map
-                    if let Some(value) = trust_diff_map.get_mut(trusted_user) {
-                        *value -= 1.0;
-                    }
+                    // for this trusted_user insert a record that he was untrusted by this user
+                    let untrusting_users_list: &mut Vec<String> = lost_trust_from.entry(trusted_user.to_string()).or_insert(vec![]);
+                    untrusting_users_list.push(user.to_string());
                 }
             });
         }
-        trust_diff_map
+
+        // calculate a sum of nqg scores of all users who untrusted each user
+        let untrusted_by_nqg_amount: HashMap<String, f64> = lost_trust_from
+            .iter()
+            .map(|(user, lost_trust)| (user.to_string(), self.sum_nqg_of_users(lost_trust)))
+            .collect();
+
+        console::log_1(&JsValue::from_str(&format!("untrusted_by_nqg_amount: {:?}", untrusted_by_nqg_amount)));
+
+        // pass those sums through logistic curve
+        for (affected_user, amount) in untrusted_by_nqg_amount {
+            let percentage_of_nqg_to_remove = generalised_logistic_function(0.0, 100.0, 1.0, 1.0, 0.2, 1.0, 50.0, amount);
+            if let Some(value) = result.get_mut(&affected_user) {
+                *value = -self.neurons_results_sum.get(&affected_user).unwrap() * percentage_of_nqg_to_remove / 100.0;
+            }
+        }
+        result
     }
 }
 

--- a/neurons/src/trust_loss.rs
+++ b/neurons/src/trust_loss.rs
@@ -144,18 +144,11 @@ mod tests {
         }
         for (name, expected) in overrides {
             let actual = result[*name];
-            assert!(
-                (actual - expected).abs() < EPS,
-                "for {name}: expected {expected}, got {actual}"
-            );
+            assert!((actual - expected).abs() < EPS, "for {name}: expected {expected}, got {actual}");
         }
         for name in user_list {
             if !overrides.iter().any(|(n, _)| n == name) {
-                assert!(
-                    result[*name].abs() < EPS,
-                    "expected {name} to be 0.0, got {}",
-                    result[*name]
-                );
+                assert!(result[*name].abs() < EPS, "expected {name} to be 0.0, got {}", result[*name]);
             }
         }
     }

--- a/neurons/src/trust_loss.rs
+++ b/neurons/src/trust_loss.rs
@@ -1,8 +1,10 @@
 use crate::{neurons::Neuron, types::generalised_logistic_function};
 use std::collections::HashMap;
 
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen::JsValue;
-use web_sys::{self, console};
+#[cfg(target_arch = "wasm32")]
+use web_sys::console;
 
 const HOW_DEEP: u32 = 32;
 #[derive(Clone, Debug)]
@@ -80,6 +82,7 @@ impl Neuron for TrustLossNeuron {
             .map(|(user, lost_trust)| (user.to_string(), self.sum_nqg_of_users(lost_trust)))
             .collect();
 
+        #[cfg(target_arch = "wasm32")]
         console::log_1(&JsValue::from_str(&format!("untrusted_by_nqg_amount: {:?}", untrusted_by_nqg_amount)));
 
         // pass those sums through logistic curve
@@ -96,6 +99,9 @@ impl Neuron for TrustLossNeuron {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::generalised_logistic_function;
+
+    const EPS: f64 = 1e-9;
 
     fn users(names: &[&str]) -> Vec<String> {
         names.iter().map(|x| x.to_string()).collect()
@@ -105,12 +111,53 @@ mod tests {
         names.iter().map(|x| x.to_string()).collect()
     }
 
-    fn expected_result(user_names: &[&str], overrides: &[(&str, f64)]) -> HashMap<String, f64> {
-        let mut result: HashMap<String, f64> = user_names.iter().map(|name| (name.to_string(), 0.0)).collect();
-        for (name, value) in overrides {
-            result.insert(name.to_string(), *value);
+    fn nqg_for(name: &str) -> f64 {
+        match name {
+            "alice" => 10.0,
+            "bob" => 15.0,
+            "charlie" => 12.0,
+            "dave" => 8.0,
+            "eve" => 20.0,
+            "tom" => 18.0,
+            "andy" => 25.0,
+            "john" => 5.0,
+            "adam" => 3.0,
+            "newuser" => 7.0,
+            "unknown_user" => 2.0,
+            _ => 1.0,
         }
-        result
+    }
+
+    fn nqg_map(names: &[&str]) -> HashMap<String, f64> {
+        names.iter().map(|n| (n.to_string(), nqg_for(n))).collect()
+    }
+
+    fn expected_loss(untrusting_nqg_sum: f64, affected_user_nqg: f64) -> f64 {
+        let pct = generalised_logistic_function(0.0, 100.0, 1.0, 1.0, 0.2, 1.0, 50.0, untrusting_nqg_sum);
+        -affected_user_nqg * pct / 100.0
+    }
+
+    fn assert_result_close(result: &HashMap<String, f64>, user_list: &[&str], overrides: &[(&str, f64)]) {
+        assert_eq!(result.len(), user_list.len());
+        for name in user_list {
+            assert!(result.contains_key(*name), "missing key {name}");
+        }
+        for (name, expected) in overrides {
+            let actual = result[*name];
+            assert!(
+                (actual - expected).abs() < EPS,
+                "for {name}: expected {expected}, got {actual}"
+            );
+        }
+        for name in user_list {
+            if !overrides.iter().any(|(n, _)| n == name) {
+                assert!(
+                    result[*name].abs() < EPS,
+                    "expected {name} to be 0.0, got {}",
+                    result[*name]
+                );
+            }
+        }
     }
 
     #[test]
@@ -133,10 +180,10 @@ mod tests {
         trust_43.insert("john".to_string(), trust_list(&["tom", "bob", "alice", "andy"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "tom", "bob", "andy", "john", "adam"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
 
-        assert_eq!(neuron.calculate_result(&users(user_list)), expected_result(user_list, &[]));
+        assert_result_close(&neuron.calculate_result(&users(user_list)), user_list, &[]);
     }
 
     #[test]
@@ -159,10 +206,10 @@ mod tests {
         trust_43.insert("john".to_string(), trust_list(&["tom", "bob", "alice", "andy"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "tom", "bob", "andy", "john", "adam"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
 
-        assert_eq!(neuron.calculate_result(&users(user_list)), expected_result(user_list, &[]));
+        assert_result_close(&neuron.calculate_result(&users(user_list)), user_list, &[]);
     }
 
     #[test]
@@ -185,15 +232,19 @@ mod tests {
         trust_43.insert("john".to_string(), trust_list(&["tom", "bob", "alice", "andy"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "tom", "bob", "andy", "john"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
+        let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(neuron.calculate_result(&users(user_list)), expected_result(user_list, &[("andy", -2.0), ("bob", -1.0)]));
+        // alice (nqg=10) untrusted bob; tom (nqg=18) + bob (nqg=15) untrusted andy
+        let expected_bob = expected_loss(nqg_for("alice"), nqg_for("bob"));
+        let expected_andy = expected_loss(nqg_for("tom") + nqg_for("bob"), nqg_for("andy"));
+        assert_result_close(&result, user_list, &[("bob", expected_bob), ("andy", expected_andy)]);
     }
 
     #[test]
     fn name_returns_correct_value() {
-        let neuron = TrustLossNeuron::from_data(44, HashMap::new());
+        let neuron = TrustLossNeuron::from_data(44, HashMap::new(), HashMap::new());
         assert_eq!(neuron.name(), "trust_loss_neuron");
     }
 
@@ -208,15 +259,15 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, HashMap::new());
         assert_eq!(neuron.calculate_result(&[]), HashMap::new());
     }
 
     #[test]
     fn empty_trust_data_returns_all_users_with_zero() {
-        let neuron = TrustLossNeuron::from_data(44, HashMap::new());
         let user_list = &["alice", "bob"];
-        assert_eq!(neuron.calculate_result(&users(user_list)), expected_result(user_list, &[]));
+        let neuron = TrustLossNeuron::from_data(44, HashMap::new(), nqg_map(user_list));
+        assert_result_close(&neuron.calculate_result(&users(user_list)), user_list, &[]);
     }
 
     #[test]
@@ -232,10 +283,10 @@ mod tests {
         trust_43.insert("charlie".to_string(), trust_list(&["bob", "alice"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
-        assert_eq!(result, expected_result(user_list, &[]));
+        assert_result_close(&result, user_list, &[]);
     }
 
     #[test]
@@ -251,11 +302,13 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "newuser"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("charlie", -1.0)]));
+        // alice (nqg=10) untrusted charlie
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 
     #[test]
@@ -270,10 +323,10 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "outsider"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
-        assert_eq!(result, expected_result(user_list, &[]));
+        assert_result_close(&result, user_list, &[]);
     }
 
     #[test]
@@ -292,11 +345,13 @@ mod tests {
         trust_43.insert("dave".to_string(), trust_list(&["bob", "eve"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "dave", "eve"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("eve", -3.0)]));
+        // alice (10) + charlie (12) + dave (8) = 30 untrusted eve (20)
+        let expected_eve = expected_loss(nqg_for("alice") + nqg_for("charlie") + nqg_for("dave"), nqg_for("eve"));
+        assert_result_close(&result, user_list, &[("eve", expected_eve)]);
     }
 
     #[test]
@@ -311,11 +366,12 @@ mod tests {
         trust_40.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(40, trust_40);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("charlie", -1.0)]));
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 
     #[test]
@@ -334,11 +390,13 @@ mod tests {
         trust_42.insert("alice".to_string(), trust_list(&["bob", "charlie", "dave"]));
         trusted_for_user_per_round.insert(42, trust_42);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "dave"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("charlie", -1.0)]));
+        // only charlie removed (comparing against round 43, not 42)
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 
     #[test]
@@ -353,10 +411,10 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&[]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
-        assert_eq!(result, expected_result(user_list, &[]));
+        assert_result_close(&result, user_list, &[]);
     }
 
     #[test]
@@ -367,10 +425,10 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
-        assert_eq!(result, expected_result(user_list, &[]));
+        assert_result_close(&result, user_list, &[]);
     }
 
     #[test]
@@ -385,11 +443,12 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "dave"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("charlie", -1.0)]));
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 
     #[test]
@@ -404,11 +463,12 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "unknown_user"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
-        assert_eq!(result, expected_result(user_list, &[("charlie", -1.0)]));
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 
     #[test]
@@ -423,18 +483,12 @@ mod tests {
         trust_43.insert("alice".to_string(), trust_list(&["bob", "charlie"]));
         trusted_for_user_per_round.insert(43, trust_43);
 
-        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round);
         let user_list = &["alice", "bob", "charlie", "dave", "eve"];
+        let neuron = TrustLossNeuron::from_data(44, trusted_for_user_per_round, nqg_map(user_list));
         let result = neuron.calculate_result(&users(user_list));
 
         assert_eq!(result.len(), 5);
-        for name in user_list {
-            assert!(result.contains_key(*name));
-        }
-        assert_eq!(result["charlie"], -1.0);
-        assert_eq!(result["alice"], 0.0);
-        assert_eq!(result["bob"], 0.0);
-        assert_eq!(result["dave"], 0.0);
-        assert_eq!(result["eve"], 0.0);
+        let expected_charlie = expected_loss(nqg_for("alice"), nqg_for("charlie"));
+        assert_result_close(&result, user_list, &[("charlie", expected_charlie)]);
     }
 }


### PR DESCRIPTION
Trust loss neuron logic change:
when someone is actively removed from other voters trust list, their nqg is summed and passe through a log curve, the output a % of total NQG to be removed from targets score.
Example:
User A with nqg 20
User B with nqg 10
User C with nqg 25
all remove user D from their trusted list, so 20+10+25 = 55 is passed through log curve, output will be 73.1%, so user D will loose 73.1% of their NQG in this round.

It is deliberately made so it acts aggressively only after some threshold of total NQG removed is passed 